### PR TITLE
ci: add commitlint with lefthook

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+export default { extends: ["@commitlint/config-conventional"] };

--- a/cspell.json
+++ b/cspell.json
@@ -7,6 +7,7 @@
     "backlight",
     "backlit",
     "behaviour",
+    "commitlint",
     "contentfiles",
     "csharpier",
     "cutout",

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,3 +1,8 @@
+commit-msg:
+  commands:
+    commitlint:
+      run: npx commitlint --edit {1}
+
 pre-push:
   parallel: true
   commands:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "licenseUrl": "https://github.com/hrpnx/unity-extensions/blob/main/LICENSE",
   "vpmDependencies": {},
   "scripts": {
+    "prepare": "lefthook install",
     "lint": "run-p lint:*",
     "lint:csharpier": "dotnet csharpier check .",
     "lint:cspell": "cspell \"**/*\" --no-progress --gitignore",
@@ -19,7 +20,10 @@
     "lint:secretlint": "secretlint \"**/*\""
   },
   "devDependencies": {
+    "@commitlint/cli": "^19.7.1",
+    "@commitlint/config-conventional": "^19.7.1",
     "@secretlint/secretlint-rule-preset-recommend": "^11.3.0",
+    "lefthook": "^1.11.3",
     "cspell": "^8.17.5",
     "editorconfig-checker": "^6.0.1",
     "npm-run-all2": "^8.0.4",


### PR DESCRIPTION
## Summary
- commitlint を導入し、Conventional Commits 形式を強制
- lefthook の commit-msg フックで検証を実行
- `npm install` 時に自動で lefthook がセットアップされるように prepare スクリプトを追加

## Test plan
- [x] `npm install` で lefthook がインストールされることを確認
- [x] 不正なコミットメッセージ（例: `test`）がブロックされることを確認
- [x] 正しいコミットメッセージ（例: `feat: add feature`）が通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)