### PR TITLE
refactor: CheekPuffResetter - Puff only, monitor CheekPuffLeft/Right

### DIFF
--- a/Editor/CheekPuffResetterPlugin.cs
+++ b/Editor/CheekPuffResetterPlugin.cs
@@ -106,7 +106,6 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
             var controller = CreateAnimatorController(
                 resetter.Mode,
                 resetter.Threshold,
-                resetter.SuckThreshold,
                 enableClipL,
                 disableClipL,
                 enableClipR,
@@ -155,8 +154,7 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
 
         private static AnimatorController CreateAnimatorController(
             MonitorMode mode,
-            float puffThreshold,
-            float suckThreshold,
+            float threshold,
             AnimationClip enableClipL,
             AnimationClip disableClipL,
             AnimationClip enableClipR,
@@ -165,22 +163,8 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
         {
             var controller = new AnimatorController();
 
-            string paramLeft;
-            string paramRight;
-            float threshold;
-
-            if (mode == MonitorMode.PuffOnly)
-            {
-                paramLeft = ParamPuffLeft;
-                paramRight = ParamPuffRight;
-                threshold = puffThreshold;
-            }
-            else
-            {
-                paramLeft = ParamSuckLeft;
-                paramRight = ParamSuckRight;
-                threshold = suckThreshold;
-            }
+            string paramLeft = mode == MonitorMode.PuffOnly ? ParamPuffLeft : ParamSuckLeft;
+            string paramRight = mode == MonitorMode.PuffOnly ? ParamPuffRight : ParamSuckRight;
 
             controller.AddParameter(
                 new AnimatorControllerParameter

--- a/Editor/CheekPuffResetterPlugin.cs
+++ b/Editor/CheekPuffResetterPlugin.cs
@@ -163,8 +163,8 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
         {
             var controller = new AnimatorController();
 
-            string paramLeft = mode == MonitorMode.PuffOnly ? ParamPuffLeft : ParamSuckLeft;
-            string paramRight = mode == MonitorMode.PuffOnly ? ParamPuffRight : ParamSuckRight;
+            string paramLeft = mode == MonitorMode.Puff ? ParamPuffLeft : ParamSuckLeft;
+            string paramRight = mode == MonitorMode.Puff ? ParamPuffRight : ParamSuckRight;
 
             controller.AddParameter(
                 new AnimatorControllerParameter
@@ -257,8 +257,8 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
 
             var parameters = gameObject.AddComponent<ModularAvatarParameters>();
 
-            string paramLeft = resetter.Mode == MonitorMode.PuffOnly ? ParamPuffLeft : ParamSuckLeft;
-            string paramRight = resetter.Mode == MonitorMode.PuffOnly ? ParamPuffRight : ParamSuckRight;
+            string paramLeft = resetter.Mode == MonitorMode.Puff ? ParamPuffLeft : ParamSuckLeft;
+            string paramRight = resetter.Mode == MonitorMode.Puff ? ParamPuffRight : ParamSuckRight;
 
             parameters.parameters.Add(
                 new ParameterConfig

--- a/Editor/CheekPuffResetterPlugin.cs
+++ b/Editor/CheekPuffResetterPlugin.cs
@@ -14,15 +14,13 @@ using VRC.SDK3.Avatars.Components;
 namespace Hrpnx.UnityExtensions.CheekPuffResetter
 {
     /// <summary>
-    /// CheekPuff / CheekSuck PhysBone リセットギミックを FX レイヤーに組み込む NDMF プラグイン
+    /// CheekPuffLeft/Right PhysBone リセットギミックを FX レイヤーに組み込む NDMF プラグイン
     /// </summary>
     public class CheekPuffResetterPlugin : Plugin<CheekPuffResetterPlugin>
     {
         private const string PluginName = "CheekPuffResetter";
-        private const string ParamPuffLeft = "CheekPuffLeft";
-        private const string ParamPuffRight = "CheekPuffRight";
-        private const string ParamSuckLeft = "CheekSuckLeft";
-        private const string ParamSuckRight = "CheekSuckRight";
+        private const string ParamLeft = "CheekPuffLeft";
+        private const string ParamRight = "CheekPuffRight";
 
         public override string QualifiedName => "dev.hrpnx.cheekpuff-resetter";
         public override string DisplayName => "CheekPuff Resetter";
@@ -104,7 +102,6 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
             CreateAsset(disableClipR, $"{assetDir}/Disable_R.anim");
 
             var controller = CreateAnimatorController(
-                resetter.Mode,
                 resetter.Threshold,
                 enableClipL,
                 disableClipL,
@@ -153,7 +150,6 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
         }
 
         private static AnimatorController CreateAnimatorController(
-            MonitorMode mode,
             float threshold,
             AnimationClip enableClipL,
             AnimationClip disableClipL,
@@ -163,13 +159,10 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
         {
             var controller = new AnimatorController();
 
-            string paramLeft = mode == MonitorMode.Puff ? ParamPuffLeft : ParamSuckLeft;
-            string paramRight = mode == MonitorMode.Puff ? ParamPuffRight : ParamSuckRight;
-
             controller.AddParameter(
                 new AnimatorControllerParameter
                 {
-                    name = paramLeft,
+                    name = ParamLeft,
                     type = AnimatorControllerParameterType.Float,
                     defaultFloat = 0f,
                 }
@@ -177,7 +170,7 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
             controller.AddParameter(
                 new AnimatorControllerParameter
                 {
-                    name = paramRight,
+                    name = ParamRight,
                     type = AnimatorControllerParameterType.Float,
                     defaultFloat = 0f,
                 }
@@ -194,14 +187,14 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
 
             SetupResetLayer(
                 layers[0].stateMachine,
-                paramLeft,
+                ParamLeft,
                 threshold,
                 enableClipL,
                 disableClipL
             );
             SetupResetLayer(
                 layers[1].stateMachine,
-                paramRight,
+                ParamRight,
                 threshold,
                 enableClipR,
                 disableClipR
@@ -241,7 +234,7 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
 
             stateMachine.defaultState = idle;
 
-            // Idle → Resetting: パラメータが閾値を超えたらリセット開始
+            // Idle → Resetting: CheekPuffLeft/Right が閾値を超えたらリセット開始
             var toResetting = idle.AddTransition(resetting);
             toResetting.AddCondition(AnimatorConditionMode.Greater, threshold, paramName);
             toResetting.hasExitTime = false;
@@ -269,13 +262,10 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
 
             var parameters = gameObject.AddComponent<ModularAvatarParameters>();
 
-            string paramLeft = resetter.Mode == MonitorMode.Puff ? ParamPuffLeft : ParamSuckLeft;
-            string paramRight = resetter.Mode == MonitorMode.Puff ? ParamPuffRight : ParamSuckRight;
-
             parameters.parameters.Add(
                 new ParameterConfig
                 {
-                    nameOrPrefix = paramLeft,
+                    nameOrPrefix = ParamLeft,
                     defaultValue = 0f,
                     saved = false,
                     syncType = ParameterSyncType.Float,
@@ -284,7 +274,7 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
             parameters.parameters.Add(
                 new ParameterConfig
                 {
-                    nameOrPrefix = paramRight,
+                    nameOrPrefix = ParamRight,
                     defaultValue = 0f,
                     saved = false,
                     syncType = ParameterSyncType.Float,

--- a/Editor/CheekPuffResetterPlugin.cs
+++ b/Editor/CheekPuffResetterPlugin.cs
@@ -14,13 +14,15 @@ using VRC.SDK3.Avatars.Components;
 namespace Hrpnx.UnityExtensions.CheekPuffResetter
 {
     /// <summary>
-    /// CheekPuff PhysBone リセットギミックを FX レイヤーに組み込む NDMF プラグイン
+    /// CheekPuff / CheekSuck PhysBone リセットギミックを FX レイヤーに組み込む NDMF プラグイン
     /// </summary>
     public class CheekPuffResetterPlugin : Plugin<CheekPuffResetterPlugin>
     {
         private const string PluginName = "CheekPuffResetter";
-        private const string ParamLeft = "CheekPuffLeft";
-        private const string ParamRight = "CheekPuffRight";
+        private const string ParamPuffLeft = "CheekPuffLeft";
+        private const string ParamPuffRight = "CheekPuffRight";
+        private const string ParamSuckLeft = "CheekSuckLeft";
+        private const string ParamSuckRight = "CheekSuckRight";
 
         public override string QualifiedName => "dev.hrpnx.cheekpuff-resetter";
         public override string DisplayName => "CheekPuff Resetter";
@@ -102,7 +104,9 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
             CreateAsset(disableClipR, $"{assetDir}/Disable_R.anim");
 
             var controller = CreateAnimatorController(
+                resetter.Mode,
                 resetter.Threshold,
+                resetter.SuckThreshold,
                 enableClipL,
                 disableClipL,
                 enableClipR,
@@ -150,7 +154,9 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
         }
 
         private static AnimatorController CreateAnimatorController(
-            float threshold,
+            MonitorMode mode,
+            float puffThreshold,
+            float suckThreshold,
             AnimationClip enableClipL,
             AnimationClip disableClipL,
             AnimationClip enableClipR,
@@ -159,25 +165,48 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
         {
             var controller = new AnimatorController();
 
-            controller.AddParameter(
-                new AnimatorControllerParameter
-                {
-                    name = ParamLeft,
-                    type = AnimatorControllerParameterType.Float,
-                    defaultFloat = 0f,
-                }
-            );
-            controller.AddParameter(
-                new AnimatorControllerParameter
-                {
-                    name = ParamRight,
-                    type = AnimatorControllerParameterType.Float,
-                    defaultFloat = 0f,
-                }
-            );
+            if (mode == MonitorMode.PuffOnly || mode == MonitorMode.Both)
+            {
+                controller.AddParameter(
+                    new AnimatorControllerParameter
+                    {
+                        name = ParamPuffLeft,
+                        type = AnimatorControllerParameterType.Float,
+                        defaultFloat = 0f,
+                    }
+                );
+                controller.AddParameter(
+                    new AnimatorControllerParameter
+                    {
+                        name = ParamPuffRight,
+                        type = AnimatorControllerParameterType.Float,
+                        defaultFloat = 0f,
+                    }
+                );
+            }
 
-            controller.AddLayer("CheekPuff_Reset_L");
-            controller.AddLayer("CheekPuff_Reset_R");
+            if (mode == MonitorMode.SuckOnly || mode == MonitorMode.Both)
+            {
+                controller.AddParameter(
+                    new AnimatorControllerParameter
+                    {
+                        name = ParamSuckLeft,
+                        type = AnimatorControllerParameterType.Float,
+                        defaultFloat = 0f,
+                    }
+                );
+                controller.AddParameter(
+                    new AnimatorControllerParameter
+                    {
+                        name = ParamSuckRight,
+                        type = AnimatorControllerParameterType.Float,
+                        defaultFloat = 0f,
+                    }
+                );
+            }
+
+            controller.AddLayer("CheekReset_L");
+            controller.AddLayer("CheekReset_R");
 
             // AddLayer で追加した 2 層目以降は defaultWeight = 0 のため書き戻す
             var layers = controller.layers;
@@ -185,17 +214,26 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
             layers[1].defaultWeight = 1f;
             controller.layers = layers;
 
+            string puffParamL = (mode == MonitorMode.PuffOnly || mode == MonitorMode.Both) ? ParamPuffLeft : null;
+            string puffParamR = (mode == MonitorMode.PuffOnly || mode == MonitorMode.Both) ? ParamPuffRight : null;
+            string suckParamL = (mode == MonitorMode.SuckOnly || mode == MonitorMode.Both) ? ParamSuckLeft : null;
+            string suckParamR = (mode == MonitorMode.SuckOnly || mode == MonitorMode.Both) ? ParamSuckRight : null;
+
             SetupResetLayer(
-                controller.layers[0].stateMachine,
-                ParamLeft,
-                threshold,
+                layers[0].stateMachine,
+                puffParamL,
+                puffThreshold,
+                suckParamL,
+                suckThreshold,
                 enableClipL,
                 disableClipL
             );
             SetupResetLayer(
-                controller.layers[1].stateMachine,
-                ParamRight,
-                threshold,
+                layers[1].stateMachine,
+                puffParamR,
+                puffThreshold,
+                suckParamR,
+                suckThreshold,
                 enableClipR,
                 disableClipR
             );
@@ -206,12 +244,17 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
         /// <summary>
         /// 1 レイヤー分のステートマシンを構築する。
         ///
-        /// Idle (有効) → Resetting (無効化、クリップ再生完了まで待機) → WaitRelease (再有効化) → Idle (パラメータが閾値未満)
+        /// Idle (有効) → Resetting (無効化、クリップ再生完了まで待機) → WaitRelease (再有効化) → Idle (全パラメータが閾値未満)
+        ///
+        /// Both モード時、Idle → Resetting はいずれかのパラメータが閾値超過で遷移する（OR 条件）。
+        /// WaitRelease → Idle は全パラメータが閾値未満に戻った場合に遷移する（AND 条件）。
         /// </summary>
         private static void SetupResetLayer(
             AnimatorStateMachine stateMachine,
-            string paramName,
-            float threshold,
+            string puffParamName,
+            float puffThreshold,
+            string suckParamName,
+            float suckThreshold,
             AnimationClip enableClip,
             AnimationClip disableClip
         )
@@ -234,11 +277,23 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
 
             stateMachine.defaultState = idle;
 
-            // Idle → Resetting: パラメータが閾値を超えたらリセット開始
-            var toResetting = idle.AddTransition(resetting);
-            toResetting.AddCondition(AnimatorConditionMode.Greater, threshold, paramName);
-            toResetting.hasExitTime = false;
-            toResetting.duration = 0f;
+            // Idle → Resetting: Puff が閾値超過（OR 条件の 1 つ目）
+            if (puffParamName != null)
+            {
+                var t = idle.AddTransition(resetting);
+                t.AddCondition(AnimatorConditionMode.Greater, puffThreshold, puffParamName);
+                t.hasExitTime = false;
+                t.duration = 0f;
+            }
+
+            // Idle → Resetting: Suck が閾値超過（OR 条件の 2 つ目）
+            if (suckParamName != null)
+            {
+                var t = idle.AddTransition(resetting);
+                t.AddCondition(AnimatorConditionMode.Greater, suckThreshold, suckParamName);
+                t.hasExitTime = false;
+                t.duration = 0f;
+            }
 
             // Resetting → WaitRelease: disable クリップを 1 回再生し終えたら遷移 (PhysBone が確実に無効化される)
             var toWaitRelease = resetting.AddTransition(waitRelease);
@@ -246,9 +301,16 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
             toWaitRelease.exitTime = 1.0f;
             toWaitRelease.duration = 0f;
 
-            // WaitRelease → Idle: パラメータが閾値未満に戻ったら待機解除
+            // WaitRelease → Idle: 全パラメータが閾値未満に戻ったら待機解除（AND 条件）
             var toIdle = waitRelease.AddTransition(idle);
-            toIdle.AddCondition(AnimatorConditionMode.Less, threshold, paramName);
+            if (puffParamName != null)
+            {
+                toIdle.AddCondition(AnimatorConditionMode.Less, puffThreshold, puffParamName);
+            }
+            if (suckParamName != null)
+            {
+                toIdle.AddCondition(AnimatorConditionMode.Less, suckThreshold, suckParamName);
+            }
             toIdle.hasExitTime = false;
             toIdle.duration = 0f;
         }
@@ -261,24 +323,50 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
             var gameObject = resetter.gameObject;
 
             var parameters = gameObject.AddComponent<ModularAvatarParameters>();
-            parameters.parameters.Add(
-                new ParameterConfig
-                {
-                    nameOrPrefix = ParamLeft,
-                    defaultValue = 0f,
-                    saved = false,
-                    syncType = ParameterSyncType.Float,
-                }
-            );
-            parameters.parameters.Add(
-                new ParameterConfig
-                {
-                    nameOrPrefix = ParamRight,
-                    defaultValue = 0f,
-                    saved = false,
-                    syncType = ParameterSyncType.Float,
-                }
-            );
+
+            if (resetter.Mode == MonitorMode.PuffOnly || resetter.Mode == MonitorMode.Both)
+            {
+                parameters.parameters.Add(
+                    new ParameterConfig
+                    {
+                        nameOrPrefix = ParamPuffLeft,
+                        defaultValue = 0f,
+                        saved = false,
+                        syncType = ParameterSyncType.Float,
+                    }
+                );
+                parameters.parameters.Add(
+                    new ParameterConfig
+                    {
+                        nameOrPrefix = ParamPuffRight,
+                        defaultValue = 0f,
+                        saved = false,
+                        syncType = ParameterSyncType.Float,
+                    }
+                );
+            }
+
+            if (resetter.Mode == MonitorMode.SuckOnly || resetter.Mode == MonitorMode.Both)
+            {
+                parameters.parameters.Add(
+                    new ParameterConfig
+                    {
+                        nameOrPrefix = ParamSuckLeft,
+                        defaultValue = 0f,
+                        saved = false,
+                        syncType = ParameterSyncType.Float,
+                    }
+                );
+                parameters.parameters.Add(
+                    new ParameterConfig
+                    {
+                        nameOrPrefix = ParamSuckRight,
+                        defaultValue = 0f,
+                        saved = false,
+                        syncType = ParameterSyncType.Float,
+                    }
+                );
+            }
 
             var mergeAnimator = gameObject.AddComponent<ModularAvatarMergeAnimator>();
             mergeAnimator.animator = controller;

--- a/Editor/CheekPuffResetterPlugin.cs
+++ b/Editor/CheekPuffResetterPlugin.cs
@@ -192,8 +192,20 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
             layers[1].defaultWeight = 1f;
             controller.layers = layers;
 
-            SetupResetLayer(layers[0].stateMachine, paramLeft, threshold, enableClipL, disableClipL);
-            SetupResetLayer(layers[1].stateMachine, paramRight, threshold, enableClipR, disableClipR);
+            SetupResetLayer(
+                layers[0].stateMachine,
+                paramLeft,
+                threshold,
+                enableClipL,
+                disableClipL
+            );
+            SetupResetLayer(
+                layers[1].stateMachine,
+                paramRight,
+                threshold,
+                enableClipR,
+                disableClipR
+            );
 
             return controller;
         }

--- a/Editor/CheekPuffResetterPlugin.cs
+++ b/Editor/CheekPuffResetterPlugin.cs
@@ -165,45 +165,39 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
         {
             var controller = new AnimatorController();
 
-            if (mode == MonitorMode.PuffOnly || mode == MonitorMode.Both)
+            string paramLeft;
+            string paramRight;
+            float threshold;
+
+            if (mode == MonitorMode.PuffOnly)
             {
-                controller.AddParameter(
-                    new AnimatorControllerParameter
-                    {
-                        name = ParamPuffLeft,
-                        type = AnimatorControllerParameterType.Float,
-                        defaultFloat = 0f,
-                    }
-                );
-                controller.AddParameter(
-                    new AnimatorControllerParameter
-                    {
-                        name = ParamPuffRight,
-                        type = AnimatorControllerParameterType.Float,
-                        defaultFloat = 0f,
-                    }
-                );
+                paramLeft = ParamPuffLeft;
+                paramRight = ParamPuffRight;
+                threshold = puffThreshold;
+            }
+            else
+            {
+                paramLeft = ParamSuckLeft;
+                paramRight = ParamSuckRight;
+                threshold = suckThreshold;
             }
 
-            if (mode == MonitorMode.SuckOnly || mode == MonitorMode.Both)
-            {
-                controller.AddParameter(
-                    new AnimatorControllerParameter
-                    {
-                        name = ParamSuckLeft,
-                        type = AnimatorControllerParameterType.Float,
-                        defaultFloat = 0f,
-                    }
-                );
-                controller.AddParameter(
-                    new AnimatorControllerParameter
-                    {
-                        name = ParamSuckRight,
-                        type = AnimatorControllerParameterType.Float,
-                        defaultFloat = 0f,
-                    }
-                );
-            }
+            controller.AddParameter(
+                new AnimatorControllerParameter
+                {
+                    name = paramLeft,
+                    type = AnimatorControllerParameterType.Float,
+                    defaultFloat = 0f,
+                }
+            );
+            controller.AddParameter(
+                new AnimatorControllerParameter
+                {
+                    name = paramRight,
+                    type = AnimatorControllerParameterType.Float,
+                    defaultFloat = 0f,
+                }
+            );
 
             controller.AddLayer("CheekReset_L");
             controller.AddLayer("CheekReset_R");
@@ -214,29 +208,8 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
             layers[1].defaultWeight = 1f;
             controller.layers = layers;
 
-            string puffParamL = (mode == MonitorMode.PuffOnly || mode == MonitorMode.Both) ? ParamPuffLeft : null;
-            string puffParamR = (mode == MonitorMode.PuffOnly || mode == MonitorMode.Both) ? ParamPuffRight : null;
-            string suckParamL = (mode == MonitorMode.SuckOnly || mode == MonitorMode.Both) ? ParamSuckLeft : null;
-            string suckParamR = (mode == MonitorMode.SuckOnly || mode == MonitorMode.Both) ? ParamSuckRight : null;
-
-            SetupResetLayer(
-                layers[0].stateMachine,
-                puffParamL,
-                puffThreshold,
-                suckParamL,
-                suckThreshold,
-                enableClipL,
-                disableClipL
-            );
-            SetupResetLayer(
-                layers[1].stateMachine,
-                puffParamR,
-                puffThreshold,
-                suckParamR,
-                suckThreshold,
-                enableClipR,
-                disableClipR
-            );
+            SetupResetLayer(layers[0].stateMachine, paramLeft, threshold, enableClipL, disableClipL);
+            SetupResetLayer(layers[1].stateMachine, paramRight, threshold, enableClipR, disableClipR);
 
             return controller;
         }
@@ -244,17 +217,12 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
         /// <summary>
         /// 1 レイヤー分のステートマシンを構築する。
         ///
-        /// Idle (有効) → Resetting (無効化、クリップ再生完了まで待機) → WaitRelease (再有効化) → Idle (全パラメータが閾値未満)
-        ///
-        /// Both モード時、Idle → Resetting はいずれかのパラメータが閾値超過で遷移する（OR 条件）。
-        /// WaitRelease → Idle は全パラメータが閾値未満に戻った場合に遷移する（AND 条件）。
+        /// Idle (有効) → Resetting (無効化、クリップ再生完了まで待機) → WaitRelease (再有効化) → Idle (パラメータが閾値未満)
         /// </summary>
         private static void SetupResetLayer(
             AnimatorStateMachine stateMachine,
-            string puffParamName,
-            float puffThreshold,
-            string suckParamName,
-            float suckThreshold,
+            string paramName,
+            float threshold,
             AnimationClip enableClip,
             AnimationClip disableClip
         )
@@ -277,23 +245,11 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
 
             stateMachine.defaultState = idle;
 
-            // Idle → Resetting: Puff が閾値超過（OR 条件の 1 つ目）
-            if (puffParamName != null)
-            {
-                var t = idle.AddTransition(resetting);
-                t.AddCondition(AnimatorConditionMode.Greater, puffThreshold, puffParamName);
-                t.hasExitTime = false;
-                t.duration = 0f;
-            }
-
-            // Idle → Resetting: Suck が閾値超過（OR 条件の 2 つ目）
-            if (suckParamName != null)
-            {
-                var t = idle.AddTransition(resetting);
-                t.AddCondition(AnimatorConditionMode.Greater, suckThreshold, suckParamName);
-                t.hasExitTime = false;
-                t.duration = 0f;
-            }
+            // Idle → Resetting: パラメータが閾値を超えたらリセット開始
+            var toResetting = idle.AddTransition(resetting);
+            toResetting.AddCondition(AnimatorConditionMode.Greater, threshold, paramName);
+            toResetting.hasExitTime = false;
+            toResetting.duration = 0f;
 
             // Resetting → WaitRelease: disable クリップを 1 回再生し終えたら遷移 (PhysBone が確実に無効化される)
             var toWaitRelease = resetting.AddTransition(waitRelease);
@@ -301,16 +257,9 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
             toWaitRelease.exitTime = 1.0f;
             toWaitRelease.duration = 0f;
 
-            // WaitRelease → Idle: 全パラメータが閾値未満に戻ったら待機解除（AND 条件）
+            // WaitRelease → Idle: パラメータが閾値未満に戻ったら待機解除
             var toIdle = waitRelease.AddTransition(idle);
-            if (puffParamName != null)
-            {
-                toIdle.AddCondition(AnimatorConditionMode.Less, puffThreshold, puffParamName);
-            }
-            if (suckParamName != null)
-            {
-                toIdle.AddCondition(AnimatorConditionMode.Less, suckThreshold, suckParamName);
-            }
+            toIdle.AddCondition(AnimatorConditionMode.Less, threshold, paramName);
             toIdle.hasExitTime = false;
             toIdle.duration = 0f;
         }
@@ -324,49 +273,27 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
 
             var parameters = gameObject.AddComponent<ModularAvatarParameters>();
 
-            if (resetter.Mode == MonitorMode.PuffOnly || resetter.Mode == MonitorMode.Both)
-            {
-                parameters.parameters.Add(
-                    new ParameterConfig
-                    {
-                        nameOrPrefix = ParamPuffLeft,
-                        defaultValue = 0f,
-                        saved = false,
-                        syncType = ParameterSyncType.Float,
-                    }
-                );
-                parameters.parameters.Add(
-                    new ParameterConfig
-                    {
-                        nameOrPrefix = ParamPuffRight,
-                        defaultValue = 0f,
-                        saved = false,
-                        syncType = ParameterSyncType.Float,
-                    }
-                );
-            }
+            string paramLeft = resetter.Mode == MonitorMode.PuffOnly ? ParamPuffLeft : ParamSuckLeft;
+            string paramRight = resetter.Mode == MonitorMode.PuffOnly ? ParamPuffRight : ParamSuckRight;
 
-            if (resetter.Mode == MonitorMode.SuckOnly || resetter.Mode == MonitorMode.Both)
-            {
-                parameters.parameters.Add(
-                    new ParameterConfig
-                    {
-                        nameOrPrefix = ParamSuckLeft,
-                        defaultValue = 0f,
-                        saved = false,
-                        syncType = ParameterSyncType.Float,
-                    }
-                );
-                parameters.parameters.Add(
-                    new ParameterConfig
-                    {
-                        nameOrPrefix = ParamSuckRight,
-                        defaultValue = 0f,
-                        saved = false,
-                        syncType = ParameterSyncType.Float,
-                    }
-                );
-            }
+            parameters.parameters.Add(
+                new ParameterConfig
+                {
+                    nameOrPrefix = paramLeft,
+                    defaultValue = 0f,
+                    saved = false,
+                    syncType = ParameterSyncType.Float,
+                }
+            );
+            parameters.parameters.Add(
+                new ParameterConfig
+                {
+                    nameOrPrefix = paramRight,
+                    defaultValue = 0f,
+                    saved = false,
+                    syncType = ParameterSyncType.Float,
+                }
+            );
 
             var mergeAnimator = gameObject.AddComponent<ModularAvatarMergeAnimator>();
             mergeAnimator.animator = controller;

--- a/README.md
+++ b/README.md
@@ -113,31 +113,29 @@ Some miscellaneous Unity utilities I use.
 
 ### 💨 CheekPuff Resetter
 
-フェイシャルトラッキングで頬を膨らませる／へこませる動作をトリガーとして、引っ張られて固定された頬の PhysBone をリセットするコンポーネントです。
+フェイシャルトラッキングで頬を膨らませる動作をトリガーとして、引っ張られて固定された頬の PhysBone をリセットするコンポーネントです。
 
 **主な機能：**
 
-- 頬を膨らませる (`CheekPuffLeft` / `CheekPuffRight`) または頬をへこませる (`CheekSuckLeft` / `CheekSuckRight`) OSC パラメータが閾値を超えた瞬間に対象 PhysBone をリセット
+- `CheekPuffLeft` / `CheekPuffRight` OSC パラメータが閾値を超えた瞬間に対象 PhysBone をリセット
 - Modular Avatar 経由で FX レイヤーを自動生成・マージ
 - 左右独立した FX レイヤー構成
 
 **設定項目：**
 
-| 項目         | 説明                                                        |
-| ------------ | ----------------------------------------------------------- |
-| Mode         | 頬を膨らませてリセット / 頬をへこませてリセット             |
-| Threshold    | リセットを発動するパラメータの閾値 (0–1、デフォルト 0.5)    |
-| Cheek Bone L | VRCPhysBone がついた GameObject（左頬）                     |
-| Cheek Bone R | VRCPhysBone がついた GameObject（右頬）                     |
+| 項目         | 説明                                                     |
+| ------------ | -------------------------------------------------------- |
+| Threshold    | リセットを発動するパラメータの閾値 (0–1、デフォルト 0.5) |
+| Cheek Bone L | VRCPhysBone がついた GameObject（左頬）                  |
+| Cheek Bone R | VRCPhysBone がついた GameObject（右頬）                  |
 
 **使い方：**
 
 1. アバター配下に空の GameObject を作成
 2. `CheekPuffResetter` コンポーネントを追加
-3. Mode でリセットのトリガーとなる動作を選択
-4. Cheek Bone L / R に VRCPhysBone がついた GameObject を設定
-5. (任意) Threshold を調整
-6. アバターをビルドすると FX レイヤーが自動生成されます
+3. Cheek Bone L / R に VRCPhysBone がついた GameObject を設定
+4. (任意) Threshold を調整
+5. アバターをビルドすると FX レイヤーが自動生成されます
 
 ### 🦴 Sync Clothing Bone Transforms
 

--- a/README.md
+++ b/README.md
@@ -113,29 +113,31 @@ Some miscellaneous Unity utilities I use.
 
 ### 💨 CheekPuff Resetter
 
-フェイシャルトラッキングで頬をふくらませる動作をトリガーとして、引っ張られて固定された頬の PhysBone をリセットするコンポーネントです。
+フェイシャルトラッキングで頬を膨らませる／へこませる動作をトリガーとして、引っ張られて固定された頬の PhysBone をリセットするコンポーネントです。
 
 **主な機能：**
 
-- `CheekPuffLeft` / `CheekPuffRight` OSC パラメータが閾値を超えた瞬間に対象 PhysBone をリセット
+- 頬を膨らませる (`CheekPuffLeft` / `CheekPuffRight`) または頬をへこませる (`CheekSuckLeft` / `CheekSuckRight`) OSC パラメータが閾値を超えた瞬間に対象 PhysBone をリセット
 - Modular Avatar 経由で FX レイヤーを自動生成・マージ
 - 左右独立した FX レイヤー構成
 
 **設定項目：**
 
-| 項目        | 説明                                                             |
-| ----------- | ---------------------------------------------------------------- |
-| Threshold   | リセットを発動する CheekPuff パラメータの閾値 (0–1、デフォルト 0.5) |
-| Cheek Bone L | VRCPhysBone がついた GameObject（左頬）                        |
-| Cheek Bone R | VRCPhysBone がついた GameObject（右頬）                        |
+| 項目         | 説明                                                        |
+| ------------ | ----------------------------------------------------------- |
+| Mode         | 頬を膨らませてリセット / 頬をへこませてリセット             |
+| Threshold    | リセットを発動するパラメータの閾値 (0–1、デフォルト 0.5)    |
+| Cheek Bone L | VRCPhysBone がついた GameObject（左頬）                     |
+| Cheek Bone R | VRCPhysBone がついた GameObject（右頬）                     |
 
 **使い方：**
 
 1. アバター配下に空の GameObject を作成
 2. `CheekPuffResetter` コンポーネントを追加
-3. Cheek Bone L / R に VRCPhysBone がついた GameObject を設定
-4. (任意) Threshold を調整
-5. アバターをビルドすると FX レイヤーが自動生成されます
+3. Mode でリセットのトリガーとなる動作を選択
+4. Cheek Bone L / R に VRCPhysBone がついた GameObject を設定
+5. (任意) Threshold を調整
+6. アバターをビルドすると FX レイヤーが自動生成されます
 
 ### 🦴 Sync Clothing Bone Transforms
 

--- a/Runtime/CheekPuffResetter.cs
+++ b/Runtime/CheekPuffResetter.cs
@@ -22,13 +22,9 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
         [Tooltip("監視するパラメータの種類")]
         public MonitorMode Mode = MonitorMode.PuffOnly;
 
-        [Tooltip("CheekPuffLeft/Right（頬を膨らませる）の閾値 (0-1、0.5 = 50%)")]
+        [Tooltip("閾値 (0-1、0.5 = 50%)")]
         [Range(0f, 1f)]
         public float Threshold = 0.5f;
-
-        [Tooltip("CheekSuckLeft/Right（頬をへこませる）の閾値 (0-1、0.5 = 50%)")]
-        [Range(0f, 1f)]
-        public float SuckThreshold = 0.5f;
 
         [Tooltip("リセット対象の PhysBone が付いた Transform (Cheek1_L)")]
         public Transform CheekBoneL;

--- a/Runtime/CheekPuffResetter.cs
+++ b/Runtime/CheekPuffResetter.cs
@@ -4,13 +4,33 @@ using VRC.SDKBase;
 namespace Hrpnx.UnityExtensions.CheekPuffResetter
 {
     /// <summary>
-    /// CheekPuffLeft/Right パラメータが閾値を超えた際に指定 PhysBone をリセットするコンポーネント
+    /// 頬の動き（Puff / Suck）がしきい値を超えた際に指定 PhysBone をリセットするコンポーネント
+    /// </summary>
+    public enum MonitorMode
+    {
+        [InspectorName("頬を膨らませる（Puff）のみ監視")]
+        PuffOnly,
+        [InspectorName("頬をへこます（Suck）のみ監視")]
+        SuckOnly,
+        [InspectorName("両方監視（いずれかが閾値超過でリセット）")]
+        Both,
+    }
+
+    /// <summary>
+    /// CheekPuff / CheekSuck パラメータが閾値を超えた際に指定 PhysBone をリセットするコンポーネント
     /// </summary>
     public class CheekPuffResetter : MonoBehaviour, IEditorOnly
     {
-        [Tooltip("CheekPuffLeft/Right の閾値 (VRChat float パラメータ 0-1、0.5 = 50%)")]
+        [Tooltip("監視するパラメータの種類")]
+        public MonitorMode Mode = MonitorMode.PuffOnly;
+
+        [Tooltip("CheekPuffLeft/Right（頬を膨らませる）の閾値 (0-1、0.5 = 50%)")]
         [Range(0f, 1f)]
         public float Threshold = 0.5f;
+
+        [Tooltip("CheekSuckLeft/Right（頬をへこます）の閾値 (0-1、0.5 = 50%)")]
+        [Range(0f, 1f)]
+        public float SuckThreshold = 0.5f;
 
         [Tooltip("リセット対象の PhysBone が付いた Transform (Cheek1_L)")]
         public Transform CheekBoneL;

--- a/Runtime/CheekPuffResetter.cs
+++ b/Runtime/CheekPuffResetter.cs
@@ -8,12 +8,10 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
     /// </summary>
     public enum MonitorMode
     {
-        [InspectorName("頬を膨らませる（Puff）のみ監視")]
+        [InspectorName("頬を膨らませる（Puff）")]
         PuffOnly,
-        [InspectorName("頬をへこます（Suck）のみ監視")]
+        [InspectorName("頬をへこます（Suck）")]
         SuckOnly,
-        [InspectorName("両方監視（いずれかが閾値超過でリセット）")]
-        Both,
     }
 
     /// <summary>

--- a/Runtime/CheekPuffResetter.cs
+++ b/Runtime/CheekPuffResetter.cs
@@ -10,7 +10,7 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
     {
         [InspectorName("頬を膨らませる")]
         PuffOnly,
-        [InspectorName("頬をへこます")]
+        [InspectorName("頬をへこませる")]
         SuckOnly,
     }
 
@@ -26,7 +26,7 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
         [Range(0f, 1f)]
         public float Threshold = 0.5f;
 
-        [Tooltip("CheekSuckLeft/Right（頬をへこます）の閾値 (0-1、0.5 = 50%)")]
+        [Tooltip("CheekSuckLeft/Right（頬をへこませる）の閾値 (0-1、0.5 = 50%)")]
         [Range(0f, 1f)]
         public float SuckThreshold = 0.5f;
 

--- a/Runtime/CheekPuffResetter.cs
+++ b/Runtime/CheekPuffResetter.cs
@@ -10,6 +10,7 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
     {
         [InspectorName("頬を膨らませてリセット")]
         Puff,
+
         [InspectorName("頬をへこませてリセット")]
         Suck,
     }

--- a/Runtime/CheekPuffResetter.cs
+++ b/Runtime/CheekPuffResetter.cs
@@ -8,9 +8,9 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
     /// </summary>
     public enum MonitorMode
     {
-        [InspectorName("頬を膨らませる")]
+        [InspectorName("頬を膨らませてリセット")]
         PuffOnly,
-        [InspectorName("頬をへこませる")]
+        [InspectorName("頬をへこませてリセット")]
         SuckOnly,
     }
 

--- a/Runtime/CheekPuffResetter.cs
+++ b/Runtime/CheekPuffResetter.cs
@@ -4,25 +4,10 @@ using VRC.SDKBase;
 namespace Hrpnx.UnityExtensions.CheekPuffResetter
 {
     /// <summary>
-    /// 頬の動き（Puff / Suck）がしきい値を超えた際に指定 PhysBone をリセットするコンポーネント
-    /// </summary>
-    public enum MonitorMode
-    {
-        [InspectorName("頬を膨らませてリセット")]
-        Puff,
-
-        [InspectorName("頬をへこませてリセット")]
-        Suck,
-    }
-
-    /// <summary>
-    /// CheekPuff / CheekSuck パラメータが閾値を超えた際に指定 PhysBone をリセットするコンポーネント
+    /// CheekPuffLeft/Right パラメータが閾値を超えた際に指定 PhysBone をリセットするコンポーネント
     /// </summary>
     public class CheekPuffResetter : MonoBehaviour, IEditorOnly
     {
-        [Tooltip("監視するパラメータの種類")]
-        public MonitorMode Mode = MonitorMode.Puff;
-
         [Tooltip("閾値 (0-1、0.5 = 50%)")]
         [Range(0f, 1f)]
         public float Threshold = 0.5f;

--- a/Runtime/CheekPuffResetter.cs
+++ b/Runtime/CheekPuffResetter.cs
@@ -8,9 +8,9 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
     /// </summary>
     public enum MonitorMode
     {
-        [InspectorName("頬を膨らませる（Puff）")]
+        [InspectorName("頬を膨らませる")]
         PuffOnly,
-        [InspectorName("頬をへこます（Suck）")]
+        [InspectorName("頬をへこます")]
         SuckOnly,
     }
 

--- a/Runtime/CheekPuffResetter.cs
+++ b/Runtime/CheekPuffResetter.cs
@@ -9,9 +9,9 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
     public enum MonitorMode
     {
         [InspectorName("頬を膨らませてリセット")]
-        PuffOnly,
+        Puff,
         [InspectorName("頬をへこませてリセット")]
-        SuckOnly,
+        Suck,
     }
 
     /// <summary>
@@ -20,7 +20,7 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
     public class CheekPuffResetter : MonoBehaviour, IEditorOnly
     {
         [Tooltip("監視するパラメータの種類")]
-        public MonitorMode Mode = MonitorMode.PuffOnly;
+        public MonitorMode Mode = MonitorMode.Puff;
 
         [Tooltip("閾値 (0-1、0.5 = 50%)")]
         [Range(0f, 1f)]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dev.hrpnx.unity-extensions",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dev.hrpnx.unity-extensions",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.7.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dev.hrpnx.unity-extensions",
   "type": "module",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "displayName": "hrpnx's Unity Extensions",
   "description": "Some miscellaneous Unity utilities I use.",
   "unity": "2022.3",


### PR DESCRIPTION
## Summary

- Suck モードを削除し、Puff（頬膨らませ）のみに絞った
- 監視パラメーターを `CheekPuffLeft` / `CheekPuffRight` に統一
- `MonitorMode` enum と `Mode` フィールドを削除してコンポーネントをシンプルに
- FX レイヤー名を `CheekPuff_Reset_L/R` → `CheekReset_L/R` に整理

## 背景

`CheekPuffLeft` / `CheekPuffRight` は VRCFT の Unified Expressions パラメーター名。アバターの Expression Parameter として登録すると VRCFT が OSCQuery で発見し、顔トラデータを送信してくる。

Suck モード用の `v2/CheekPuffSuckLeft` は実機で感度が低く実用的でなかったためオミット。

## Test plan

- [x] Unity でアバタービルド → コンパイルエラーなし
- [x] VRChat 内で頬を膨らませたとき PhysBone がリセットされること
- [x] `CheekPuffLeft` / `CheekPuffRight` が VRCFT OSC Proxy を通じて届くこと