### PR TITLE
refactor: remove Suck mode from CheekPuffResetter

### DIFF
--- a/Editor/CheekPuffResetterPlugin.cs
+++ b/Editor/CheekPuffResetterPlugin.cs
@@ -14,15 +14,13 @@ using VRC.SDK3.Avatars.Components;
 namespace Hrpnx.UnityExtensions.CheekPuffResetter
 {
     /// <summary>
-    /// CheekPuff / CheekSuck PhysBone リセットギミックを FX レイヤーに組み込む NDMF プラグイン
+    /// CheekPuffLeft/Right PhysBone リセットギミックを FX レイヤーに組み込む NDMF プラグイン
     /// </summary>
     public class CheekPuffResetterPlugin : Plugin<CheekPuffResetterPlugin>
     {
         private const string PluginName = "CheekPuffResetter";
-        private const string ParamPuffLeft = "CheekPuffLeft";
-        private const string ParamPuffRight = "CheekPuffRight";
-        private const string ParamSuckLeft = "CheekSuckLeft";
-        private const string ParamSuckRight = "CheekSuckRight";
+        private const string ParamLeft = "CheekPuffLeft";
+        private const string ParamRight = "CheekPuffRight";
 
         public override string QualifiedName => "dev.hrpnx.cheekpuff-resetter";
         public override string DisplayName => "CheekPuff Resetter";
@@ -104,7 +102,6 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
             CreateAsset(disableClipR, $"{assetDir}/Disable_R.anim");
 
             var controller = CreateAnimatorController(
-                resetter.Mode,
                 resetter.Threshold,
                 enableClipL,
                 disableClipL,
@@ -153,7 +150,6 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
         }
 
         private static AnimatorController CreateAnimatorController(
-            MonitorMode mode,
             float threshold,
             AnimationClip enableClipL,
             AnimationClip disableClipL,
@@ -163,13 +159,10 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
         {
             var controller = new AnimatorController();
 
-            string paramLeft = mode == MonitorMode.Puff ? ParamPuffLeft : ParamSuckLeft;
-            string paramRight = mode == MonitorMode.Puff ? ParamPuffRight : ParamSuckRight;
-
             controller.AddParameter(
                 new AnimatorControllerParameter
                 {
-                    name = paramLeft,
+                    name = ParamLeft,
                     type = AnimatorControllerParameterType.Float,
                     defaultFloat = 0f,
                 }
@@ -177,7 +170,7 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
             controller.AddParameter(
                 new AnimatorControllerParameter
                 {
-                    name = paramRight,
+                    name = ParamRight,
                     type = AnimatorControllerParameterType.Float,
                     defaultFloat = 0f,
                 }
@@ -194,14 +187,14 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
 
             SetupResetLayer(
                 layers[0].stateMachine,
-                paramLeft,
+                ParamLeft,
                 threshold,
                 enableClipL,
                 disableClipL
             );
             SetupResetLayer(
                 layers[1].stateMachine,
-                paramRight,
+                ParamRight,
                 threshold,
                 enableClipR,
                 disableClipR
@@ -241,7 +234,7 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
 
             stateMachine.defaultState = idle;
 
-            // Idle → Resetting: パラメータが閾値を超えたらリセット開始
+            // Idle → Resetting: CheekPuffLeft/Right が閾値を超えたらリセット開始
             var toResetting = idle.AddTransition(resetting);
             toResetting.AddCondition(AnimatorConditionMode.Greater, threshold, paramName);
             toResetting.hasExitTime = false;
@@ -269,13 +262,10 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
 
             var parameters = gameObject.AddComponent<ModularAvatarParameters>();
 
-            string paramLeft = resetter.Mode == MonitorMode.Puff ? ParamPuffLeft : ParamSuckLeft;
-            string paramRight = resetter.Mode == MonitorMode.Puff ? ParamPuffRight : ParamSuckRight;
-
             parameters.parameters.Add(
                 new ParameterConfig
                 {
-                    nameOrPrefix = paramLeft,
+                    nameOrPrefix = ParamLeft,
                     defaultValue = 0f,
                     saved = false,
                     syncType = ParameterSyncType.Float,
@@ -284,7 +274,7 @@ namespace Hrpnx.UnityExtensions.CheekPuffResetter
             parameters.parameters.Add(
                 new ParameterConfig
                 {
-                    nameOrPrefix = paramRight,
+                    nameOrPrefix = ParamRight,
                     defaultValue = 0f,
                     saved = false,
                     syncType = ParameterSyncType.Float,

--- a/README.md
+++ b/README.md
@@ -113,31 +113,29 @@ Some miscellaneous Unity utilities I use.
 
 ### 💨 CheekPuff Resetter
 
-フェイシャルトラッキングで頬を膨らませる／へこませる動作をトリガーとして、引っ張られて固定された頬の PhysBone をリセットするコンポーネントです。
+フェイシャルトラッキングで頬を膨らませる動作をトリガーとして、引っ張られて固定された頬の PhysBone をリセットするコンポーネントです。
 
 **主な機能：**
 
-- 頬を膨らませる (`CheekPuffLeft` / `CheekPuffRight`) または頬をへこませる (`CheekSuckLeft` / `CheekSuckRight`) OSC パラメータが閾値を超えた瞬間に対象 PhysBone をリセット
+- `CheekPuffLeft` / `CheekPuffRight` OSC パラメータが閾値を超えた瞬間に対象 PhysBone をリセット
 - Modular Avatar 経由で FX レイヤーを自動生成・マージ
 - 左右独立した FX レイヤー構成
 
 **設定項目：**
 
-| 項目         | 説明                                                        |
-| ------------ | ----------------------------------------------------------- |
-| Mode         | 頬を膨らませてリセット / 頬をへこませてリセット             |
-| Threshold    | リセットを発動するパラメータの閾値 (0–1、デフォルト 0.5)    |
-| Cheek Bone L | VRCPhysBone がついた GameObject（左頬）                     |
-| Cheek Bone R | VRCPhysBone がついた GameObject（右頬）                     |
+| 項目         | 説明                                                     |
+| ------------ | -------------------------------------------------------- |
+| Threshold    | リセットを発動するパラメータの閾値 (0–1、デフォルト 0.5) |
+| Cheek Bone L | VRCPhysBone がついた GameObject（左頬）                  |
+| Cheek Bone R | VRCPhysBone がついた GameObject（右頬）                  |
 
 **使い方：**
 
 1. アバター配下に空の GameObject を作成
 2. `CheekPuffResetter` コンポーネントを追加
-3. Mode でリセットのトリガーとなる動作を選択
-4. Cheek Bone L / R に VRCPhysBone がついた GameObject を設定
-5. (任意) Threshold を調整
-6. アバターをビルドすると FX レイヤーが自動生成されます
+3. Cheek Bone L / R に VRCPhysBone がついた GameObject を設定
+4. (任意) Threshold を調整
+5. アバターをビルドすると FX レイヤーが自動生成されます
 
 ### 🦴 Sync Clothing Bone Transforms
 

--- a/Runtime/CheekPuffResetter.cs
+++ b/Runtime/CheekPuffResetter.cs
@@ -4,25 +4,10 @@ using VRC.SDKBase;
 namespace Hrpnx.UnityExtensions.CheekPuffResetter
 {
     /// <summary>
-    /// 頬の動き（Puff / Suck）がしきい値を超えた際に指定 PhysBone をリセットするコンポーネント
-    /// </summary>
-    public enum MonitorMode
-    {
-        [InspectorName("頬を膨らませてリセット")]
-        Puff,
-
-        [InspectorName("頬をへこませてリセット")]
-        Suck,
-    }
-
-    /// <summary>
-    /// CheekPuff / CheekSuck パラメータが閾値を超えた際に指定 PhysBone をリセットするコンポーネント
+    /// CheekPuffLeft/Right パラメータが閾値を超えた際に指定 PhysBone をリセットするコンポーネント
     /// </summary>
     public class CheekPuffResetter : MonoBehaviour, IEditorOnly
     {
-        [Tooltip("監視するパラメータの種類")]
-        public MonitorMode Mode = MonitorMode.Puff;
-
         [Tooltip("閾値 (0-1、0.5 = 50%)")]
         [Range(0f, 1f)]
         public float Threshold = 0.5f;


### PR DESCRIPTION
## Summary

- Suck モードを削除し、Puff（頬膨らませ）のみに絞った
- `MonitorMode` enum と `Mode` フィールドを削除してコンポーネントをシンプルに
- 監視パラメーターを `CheekPuffLeft` / `CheekPuffRight` のみに統一

## 背景

`CheekPuffLeft` / `CheekPuffRight` は VRCFT の Unified Expressions パラメーター名。アバターの Expression Parameter として登録すると VRCFT が OSCQuery で発見し、顔トラデータを送信してくる。

Suck モード用の `v2/CheekPuffSuckLeft` は実機で感度が低く実用的でなかったためオミット。

## Test plan

- [x] Unity でアバタービルド → コンパイルエラーなし
- [x] VRChat 内で頬を膨らませたとき PhysBone がリセットされること