### PR TITLE
chore: bump version to 0.7.3

### DIFF
--- a/Editor/MenuPaths.cs.meta
+++ b/Editor/MenuPaths.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db67de3441a8965469631d5933003c84
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dev.hrpnx.unity-extensions",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dev.hrpnx.unity-extensions",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.7.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dev.hrpnx.unity-extensions",
   "type": "module",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "displayName": "hrpnx's Unity Extensions",
   "description": "Some miscellaneous Unity utilities I use.",
   "unity": "2022.3",


### PR DESCRIPTION
## Summary

- `package.json` / `package-lock.json` のバージョンを 0.7.2 → 0.7.3 に更新
- `Editor/MenuPaths.cs.meta` を追加

## Changes since last release

- `refactor: remove AssetFolderBrowser and SyncClothingBoneTransforms, add MenuPaths (#30)`
- `refactor: remove Suck mode from CheekPuffResetter (#29)`

## Test plan

- [ ] GitHub Actions (`release.yml`) が正常完了することを確認
- [ ] ドラフトリリースを Publish して VPM リストに反映されることを確認