### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dev.hrpnx.unity-extensions",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dev.hrpnx.unity-extensions",
-      "version": "0.7.3",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.7.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dev.hrpnx.unity-extensions",
   "type": "module",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "displayName": "hrpnx's Unity Extensions",
   "description": "Some miscellaneous Unity utilities I use.",
   "unity": "2022.3",


### PR DESCRIPTION
## 概要
`0.7.3` → `0.8.0`（minor）。前回リリース以降に新機能 lilSSRT support が入ったため。

## 0.7.3 以降の変更
- feat: add lilSSRT support to BulkMat and BackLit (#38)
- chore(deps-dev): bump lodash 4.17.23 → 4.18.1 (#34)
- chore(deps): bump picomatch (#33)
- docs: add release skill (#32)

## 変更ファイル
- `package.json` / `package-lock.json`: version 0.8.0